### PR TITLE
Add check for existing heroku remote

### DIFF
--- a/script/ci_deploy
+++ b/script/ci_deploy
@@ -38,7 +38,7 @@ def prepare_ssh
 end
 
 def prepare_git
-  system("git remote add heroku git@heroku.com:#{HEROKU_APP}.git") || exit(1)
+  system("git remote rm heroku && git remote add heroku git@heroku.com:#{HEROKU_APP}.git") || exit(1)
 end
 
 def deploy


### PR DESCRIPTION
Sometimes builds failing because of that

```
Going to deploy develop...
fatal: remote heroku already exists.
```
