### PR TITLE
Use dotenv-rails instead of dotenv.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ end
 group :development, :test do
   gem 'fuubar'
   gem 'debugger'
-  gem 'dotenv'
+  gem 'dotenv-rails'
   gem 'rspec-rails'
   gem 'factory_girl_rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,9 @@ GEM
       railties (>= 3.2.6, < 5)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
-    dotenv (0.8.0)
+    dotenv (0.9.0)
+    dotenv-rails (0.9.0)
+      dotenv (= 0.9.0)
     email_spec (1.5.0)
       launchy (~> 2.1)
       mail (~> 2.2)
@@ -295,7 +297,7 @@ DEPENDENCIES
   debugger
   decent_exposure
   devise (~> 3.0.0)
-  dotenv
+  dotenv-rails
   email_spec
   factory_girl_rails
   foreman


### PR DESCRIPTION
dotenv gem does not requires .env or Rails load.
