### PR TITLE
Use rails secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ Application currently based on Rails 4 stable branch and Ruby 2.1.0
 
 ## Initializes
 
-* `01_config.rb` - shortcut for getting application config with `app_config`
 * `mailer.rb` - setup default hosts for mailer from configuration
 * `time_formats.rb` - setup default time formats, so you can use them like object.create_at.to_s(:us_time)
 * `requires.rb` - automatically requires everything in lib/ & lib/extensions
+
+## Core extensions
+
+* `lib/core_ext/kernel.rb` - shortcuts for getting application config with `app_config`
+   and application secrets with `app_secrets`
 
 ## Scripts
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,11 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
+# Load core extensions
+Dir[File.expand_path('../../lib/core_ext/*.rb', __FILE__)].each do |file|
+  require file
+end
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/initializers/01_config.rb
+++ b/config/initializers/01_config.rb
@@ -1,7 +1,0 @@
-# The shortcut for getting application config
-# Application config should be stored in the config/application.rb, config/environments/*.rb
-module Kernel
-  def app_config
-    Rails.application.config
-  end
-end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,7 +1,7 @@
 require 'rollbar/rails'
 
 Rollbar.configure do |config|
-  config.access_token = ENV['ROLLBAR_KEY']
+  config.access_token = app_secrets.rollbar_key
 
   # Without configuration, Rollbar is enabled by in all environments.
   # To disable in specific environments, set config.enabled=false.

--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -3,8 +3,8 @@ ActionMailer::Base.smtp_settings = {
   address:              'smtp.sendgrid.net',
   port:                 '587',
   authentication:       :plain,
-  user_name:            ENV['SENDGRID_USERNAME'],
-  password:             ENV['SENDGRID_PASSWORD'],
+  user_name:            app_secrets.sendgrid_username,
+  password:             app_secrets.sendgrid_password,
   domain:               'heroku.com',
   enable_starttls_auto: true
-} if ENV['SENDGRID_USERNAME']
+} if app_secrets.sendgrid_username

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -7,8 +7,11 @@ development:
 test:
   <<: *default
 
-staging:
+production: &production
+  sendgrid_username: <%= ENV['SENDGRID_USERNAME'] %>
+  sendgrid_password: <%= ENV['SENDGRID_PASSWORD'] %>
+  rollbar_key: <%= ENV['ROLLBAR_KEY'] %>
   <<: *default
 
-production:
-  <<: *default
+staging:
+  <<: *production

--- a/doc/README_TEMPLATE.md
+++ b/doc/README_TEMPLATE.md
@@ -39,7 +39,6 @@ bin/bootstrap
 Initializers
 -
 
-* `01_config.rb` - shortcut for getting application config with `app_config`
 * `mailer.rb` - setup default hosts for mailer from configuration
 * `time_formats.rb` - setup default time formats, so you can use them like object.create_at.to_s(:us_time)
 * `requires.rb` - automatically requires everything in lib/ & lib/extensions

--- a/lib/core_ext/kernel.rb
+++ b/lib/core_ext/kernel.rb
@@ -1,0 +1,13 @@
+module Kernel
+  def app_secrets
+    Rails.application.secrets
+  end
+
+  # The shortcut for getting application config
+  # Application config should be stored in the config/application.rb,
+  # config/environments/*.rb
+  #
+  def app_config
+    Rails.application.config
+  end
+end


### PR DESCRIPTION
#### Move third party credentials to secrets.yml as recommended in [rails guides](http://edgeguides.rubyonrails.org/4_1_release_notes.html#config/secrets.yml). 

secrets.yml - stores key value pairs, where value should be taken from `ENV` and be env specific. We suppose to share through secrets only secret data: third party credentials(rollbar, sendgrid, facebook), encryption keys etc

Other configs, like a mail_safe whitelist should not be stored in the secrets.yml and should be taken from `ENV` directly or through [custom configurations](https://github.com/fs/rails-base/issues/118)