### PR TITLE
Upgrade libv8 to newer version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.2.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)


### PR DESCRIPTION
previous one causes troubles with OS X Yosemite