### PR TITLE
Old incorrect icons classnames changed to actual

### DIFF
--- a/lib/templates/slim/scaffold/edit.html.slim
+++ b/lib/templates/slim/scaffold/edit.html.slim
@@ -1,3 +1,1 @@
-- title 'Editing <%= singular_table_name %>'
-
 = render 'form'

--- a/lib/templates/slim/scaffold/index.html.slim
+++ b/lib/templates/slim/scaffold/index.html.slim
@@ -1,5 +1,3 @@
-- title 'Listing <%= plural_table_name %>'
-
 table.table.table-striped
   thead
     tr
@@ -15,13 +13,13 @@ table.table.table-striped
 <% end -%>
       td.actions
         = link_to(<%= singular_table_name %>, class: 'btn') do
-          i.icon-eye-open
+          i.fi-eye
           |  Show
         = link_to(edit_<%= singular_table_name %>_path(<%= singular_table_name %>), class: 'btn') do
-          i.icon-edit
+          i.fi-pencil
           |  Edit
         = link_to(<%= singular_table_name %>, confirm: 'Are you sure?', method: :delete, class: 'btn btn-danger') do
-          i.icon-trash.icon-white
+          i.fi-trash
           |  Delete
 
 .paginator
@@ -29,7 +27,7 @@ table.table.table-striped
 
 br
 = link_to new_<%= singular_table_name %>_path, class: 'btn btn-primary' do
-  i.icon-plus.icon-white
+  i.fi-plus
   |  New <%= human_name %>
 
 

--- a/lib/templates/slim/scaffold/new.html.slim
+++ b/lib/templates/slim/scaffold/new.html.slim
@@ -1,3 +1,1 @@
-- title 'Create new <%= singular_table_name %>'
-
 = render 'form'

--- a/lib/templates/slim/scaffold/show.html.slim
+++ b/lib/templates/slim/scaffold/show.html.slim
@@ -1,4 +1,3 @@
-- title 'View <%= singular_table_name %>'
 .show-item
   .well.<%= singular_table_name %>.form-horizontal
 
@@ -12,7 +11,7 @@
 <% end -%>
   .form-actions
     = link_to(edit_<%= singular_table_name %>_path(<%= singular_table_name %>), class: 'btn btn-primary') do
-      i.icon-pencil.icon-white
+      i.fi-pencil
       | Edit
     '  or
     = link_to 'Back', :back


### PR DESCRIPTION
This fixes 2 problems:
1. Because of old names of icon classes icons not visible
2. After scaffolding some templates '- title' causes errors and we must move this titles to i18n files? I think it's better to delete this from templates and add somehow to localization files.