### PR TITLE
Remove .bundle/commit during bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -11,6 +11,8 @@ fi
 gem install bundler --conservative
 
 # Set up Ruby dependencies via Bundler into .bundle folder
+rm -f .bundle/config
+
 bundle check --path .bundle > /dev/null 2>&1 ||
   bundle install --path=.bundle $BUNDLER_ARGS
 


### PR DESCRIPTION
.bundle/confing stores `bundle install` options.

For example if we run once `bundle install --without development` next time
`bundle install` will be performed with saved option `--without development`.