### PR TITLE
Force double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Force double quotes everywhere: SCSS, Ruby. For more details see: https://github.com/fs/rails-base/pull/274
 - Add [SCSS-Lint](https://github.com/brigade/scss-lint) for reporting violations of SCSS coding conventions
 - Style Kaminari pagination to make it look like [Foundation's pagination](http://foundation.zurb.com/docs/v/4.3.2/components/pagination.html)
 - Add [Spring](https://github.com/rails/spring) for fast Rails actions via pre-loading

--- a/Gemfile
+++ b/Gemfile
@@ -1,78 +1,78 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby '2.2.2'
+ruby "2.2.2"
 
-gem 'rails', '4.2.1'
-gem 'pg'
+gem "rails", "4.2.1"
+gem "pg"
 
 # assets
-gem 'autoprefixer-rails'
-gem 'coffee-rails'
-gem 'foundation-icons-sass-rails'
-gem 'foundation-rails'
-gem 'jquery-rails'
-gem 'sass-rails', '~> 5.0.0'
-gem 'skim'
-gem 'therubyracer', platforms: :ruby
-gem 'uglifier', '>= 1.3.0'
+gem "autoprefixer-rails"
+gem "coffee-rails"
+gem "foundation-icons-sass-rails"
+gem "foundation-rails"
+gem "jquery-rails"
+gem "sass-rails", "~> 5.0.0"
+gem "skim"
+gem "therubyracer", platforms: :ruby
+gem "uglifier", ">= 1.3.0"
 
 # views
-gem 'active_link_to'
-gem 'simple_form'
-gem 'slim'
-gem 'title'
+gem "active_link_to"
+gem "simple_form"
+gem "slim"
+gem "title"
 
 # all other gems
-gem 'decent_exposure'
-gem 'devise'
-gem 'interactor'
-gem 'kaminari'
-gem 'responders'
-gem 'rollbar', '~> 0.10.3'
-gem 'seedbank'
-gem 'thin'
-gem 'pundit'
+gem "decent_exposure"
+gem "devise"
+gem "interactor"
+gem "kaminari"
+gem "responders"
+gem "rollbar", "~> 0.10.3"
+gem "seedbank"
+gem "thin"
+gem "pundit"
 
 group :staging, :production do
-  gem 'rails_12factor'
+  gem "rails_12factor"
 end
 
 group :test do
-  gem 'capybara'
-  gem 'capybara-webkit'
-  gem 'codeclimate-test-reporter', require: false
-  gem 'database_cleaner'
-  gem 'email_spec'
-  gem 'formulaic'
-  gem 'launchy'
-  gem 'shoulda-matchers', require: false
-  gem 'webmock', require: false
+  gem "capybara"
+  gem "capybara-webkit"
+  gem "codeclimate-test-reporter", require: false
+  gem "database_cleaner"
+  gem "email_spec"
+  gem "formulaic"
+  gem "launchy"
+  gem "shoulda-matchers", require: false
+  gem "webmock", require: false
 end
 
 group :development, :test do
-  gem 'awesome_print'
-  gem 'brakeman', require: false
-  gem 'bundler-audit'
-  gem 'byebug'
-  gem 'dotenv-rails'
-  gem 'factory_girl_rails'
-  gem 'fuubar', '~> 2.0.0.rc1'
-  gem 'jasmine', '> 2.0'
-  gem 'jasmine-jquery-rails'
-  gem 'pry-rails'
-  gem 'rails_best_practices'
-  gem 'rspec-rails', '~> 3.0'
-  gem 'rubocop'
-  gem 'scss_lint', require: false
+  gem "awesome_print"
+  gem "brakeman", require: false
+  gem "bundler-audit"
+  gem "byebug"
+  gem "dotenv-rails"
+  gem "factory_girl_rails"
+  gem "fuubar", "~> 2.0.0.rc1"
+  gem "jasmine", "> 2.0"
+  gem "jasmine-jquery-rails"
+  gem "pry-rails"
+  gem "rails_best_practices"
+  gem "rspec-rails", "~> 3.0"
+  gem "rubocop"
+  gem "scss_lint", require: false
 end
 
 group :development do
-  gem 'bullet'
-  gem 'foreman'
-  gem 'letter_opener'
-  gem 'quiet_assets'
-  gem 'slim-rails'
-  gem 'spring'
-  gem 'spring-commands-rspec'
-  gem 'web-console', '~> 2.0'
+  gem "bullet"
+  gem "foreman"
+  gem "letter_opener"
+  gem "quiet_assets"
+  gem "slim-rails"
+  gem "spring"
+  gem "spring-commands-rspec"
+  gem "web-console", "~> 2.0"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
-require 'rake'
+require File.expand_path("../config/application", __FILE__)
+require "rake"
 
 Rails.application.load_tasks

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,8 @@
-@import 'core/all';
-@import 'modules/all';
+@import "core/all";
+@import "modules/all";
 
 // Vendor libraries
-@import 'foundation-icons';
+@import "foundation-icons";
 
 // Inbox
 // The inbox allows developers, and those not actively working on the CSS,

--- a/app/assets/stylesheets/core/_foundation_and_overrides.scss
+++ b/app/assets/stylesheets/core/_foundation_and_overrides.scss
@@ -6,7 +6,7 @@
 // $rem-base: 16px;
 
 // Allows the use of rem-calc() or lower-bound() in your settings
-@import 'foundation/functions';
+@import "foundation/functions";
 
 // $experimental: true;
 
@@ -99,7 +99,7 @@
 // $medium: $medium-up;
 // $large: $large-up;
 
-//We use this as cursors values for enabling the option of having custom cursors in the whole site's stylesheet
+//We use this as cursors values for enabling the option of having custom cursors in the whole sites stylesheet
 // $cursor-crosshair-value: crosshair;
 // $cursor-default-value: default;
 // $cursor-pointer-value: pointer;
@@ -154,7 +154,7 @@
 
 // We use these to style <code> tags
 // $code-color: scale-color($alert-color, $lightness: -27%);
-// $code-font-family: Consolas, 'Liberation Mono', Courier, monospace;
+// $code-font-family: Consolas, "Liberation Mono", Courier, monospace;
 // $code-font-weight: bold;
 
 // We use these to style anchors
@@ -1193,4 +1193,4 @@
 
 // $include-html-visibility-classes: $include-html-classes;
 
-@import 'foundation';
+@import "foundation";

--- a/app/assets/stylesheets/core/_settings.scss
+++ b/app/assets/stylesheets/core/_settings.scss
@@ -1,1 +1,1 @@
-@import 'foundation_and_overrides';
+@import "foundation_and_overrides";

--- a/app/assets/stylesheets/core/all.scss
+++ b/app/assets/stylesheets/core/all.scss
@@ -5,8 +5,8 @@
 // 4. Content (base-level typography - colors, fonts)
 // 5. Layout (base-level layout - margin, padding, sizing)
 
-@import 'settings';
-@import 'helpers';
-@import 'base';
-@import 'content';
-@import 'layout';
+@import "settings";
+@import "helpers";
+@import "base";
+@import "content";
+@import "layout";

--- a/app/assets/stylesheets/modules/all.scss
+++ b/app/assets/stylesheets/modules/all.scss
@@ -10,9 +10,9 @@
 // * Navigation
 // * Sidebar
 
-@import 'header';
-@import 'footer';
-@import 'navigation';
+@import "header";
+@import "footer";
+@import "navigation";
 
-@import 'forms';
-@import 'messages';
+@import "forms";
+@import "messages";

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path("../config/environment",  __FILE__)
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
-require File.expand_path('../boot', __FILE__)
+require File.expand_path("../boot", __FILE__)
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -17,7 +17,7 @@ module RailsBase
     # config.time_zone = 'Central Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
     # config.i18n.default_locale = :de
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
@@ -29,9 +29,9 @@ module RailsBase
     config.slim_options = {}
 
     # Default e-mail address which will be shown in the "from" devise emails, initializers/devise.rb,
-    config.noreply = 'noreply@fs-rails-base.herokuapp.com'
+    config.noreply = "noreply@fs-rails-base.herokuapp.com"
 
     # Default host for action mailer, initializers/mailer.rb
-    config.host = 'localhost:5000'
+    config.host = "localhost:5000"
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('../application', __FILE__)
+require File.expand_path("../application", __FILE__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -81,5 +81,5 @@ Rails.application.configure do
 
   # Application specific options
   #
-  config.host = 'fs-rails-base.herokuapp.com'
+  config.host = "fs-rails-base.herokuapp.com"
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -76,5 +76,5 @@ Rails.application.configure do
 
   # Application specific options
   #
-  config.host = 'fs-rails-base-staging.herokuapp.com'
+  config.host = "fs-rails-base-staging.herokuapp.com"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_files  = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -13,13 +13,13 @@ Devise.setup do |config|
   config.mailer_sender = app_config.noreply
 
   # Configure the class responsible to send e-mails.
-  config.mailer = 'UserMailer'
+  config.mailer = "UserMailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -2,7 +2,7 @@ Rails.application.config.app_generators do |g|
   g.stylesheets false
   g.helper false
   g.integration_tool false
-  g.fixture_replacement(:factory_girl, dir: 'spec/factories')
+  g.fixture_replacement(:factory_girl, dir: "spec/factories")
   g.test_framework(
     :rspec,
     controller_specs: false,

--- a/config/initializers/requires.rb
+++ b/config/initializers/requires.rb
@@ -1,5 +1,5 @@
 # Require recursively all files in the lib/extensions
-Dir[Rails.root.join('lib/extensions/**/*.rb')].each { |f| require(f) }
+Dir[Rails.root.join("lib/extensions/**/*.rb")].each { |f| require(f) }
 
 # Require only files placed in the lib folder
-Dir[Rails.root.join('lib/*.rb')].each { |f| require(f) }
+Dir[Rails.root.join("lib/*.rb")].each { |f| require(f) }

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,7 +1,7 @@
-require 'rollbar/rails'
+require "rollbar/rails"
 
 Rollbar.configure do |config|
-  config.access_token = ENV['ROLLBAR_KEY']
+  config.access_token = ENV["ROLLBAR_KEY"]
 
   # Without configuration, Rollbar is enabled by in all environments.
   # To disable in specific environments, set config.enabled=false.

--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -1,10 +1,10 @@
 # Heroku specific setting for Cedar stack http://devcenter.heroku.com/articles/sendgrid#usage
 ActionMailer::Base.smtp_settings = {
-  address:              'smtp.sendgrid.net',
-  port:                 '587',
+  address:              "smtp.sendgrid.net",
+  port:                 "587",
   authentication:       :plain,
-  user_name:            ENV['SENDGRID_USERNAME'],
-  password:             ENV['SENDGRID_PASSWORD'],
-  domain:               'heroku.com',
+  user_name:            ENV["SENDGRID_USERNAME"],
+  password:             ENV["SENDGRID_PASSWORD"],
+  domain:               "heroku.com",
   enable_starttls_auto: true
-} if ENV['SENDGRID_USERNAME']
+} if ENV["SENDGRID_USERNAME"]

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_rails_base_session'
+Rails.application.config.session_store :cookie_store, key: "_rails_base_session"

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -49,7 +49,7 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: :span, class: :error }
   end
 
-  config.wrappers :foundation, class: :input, hint_class: 'has-hint', error_class: :error do |b|
+  config.wrappers :foundation, class: :input, hint_class: "has-hint", error_class: :error do |b|
     b.use :html5
     b.use :placeholder
     b.use :label
@@ -67,7 +67,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: :small, class: :hint }
   end
 
-  config.wrappers :with_labels, class: :row, hint_class: 'has-hint', error_class: :error do |b|
+  config.wrappers :with_labels, class: :row, hint_class: "has-hint", error_class: :error do |b|
     b.use :html5
     b.use :placeholder
 
@@ -76,11 +76,11 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
 
-    b.use :label, wrap_with: { class: 'large-4 medium-4 column' }
-    b.use :input, wrap_with: { class: 'large-8 medium-8 column' }
+    b.use :label, wrap_with: { class: "large-4 medium-4 column" }
+    b.use :input, wrap_with: { class: "large-8 medium-8 column" }
 
-    b.wrapper tag: 'div', class: 'large-8 medium-8 column' do |error|
-      error.use :error, wrap_with: { tag: :small, class: 'error' }
+    b.wrapper tag: "div", class: "large-8 medium-8 column" do |error|
+      error.use :error, wrap_with: { tag: :small, class: "error" }
     end
   end
 
@@ -97,7 +97,7 @@ SimpleForm.setup do |config|
   config.boolean_style = :inline
 
   # Default class for buttons
-  config.button_class = 'button'
+  config.button_class = "button"
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
@@ -108,7 +108,7 @@ SimpleForm.setup do |config|
   config.error_notification_tag = :div
 
   # CSS class to add for error notification helper.
-  config.error_notification_class = 'alert-box alert'
+  config.error_notification_class = "alert-box alert"
 
   # ID to add for error notification helper.
   # config.error_notification_id = nil
@@ -140,7 +140,7 @@ SimpleForm.setup do |config|
   # config.label_class = 'column large-4'
 
   # You can define the class to use on all forms. Default is simple_form.
-  config.default_form_class = 'simple-form'
+  config.default_form_class = "simple-form"
 
   # You can define which elements should obtain additional classes
   # config.generate_additional_classes_for = [:wrapper, :label, :input]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: 'pages#home'
+  root to: "pages#home"
 end

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -15,6 +15,9 @@ Style/SymbolArray:
   Description: 'Use %i or %I for arrays of symbols.'
   Enabled: true
 
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
 Metrics/LineLength:
   Description: 'Limit lines to 120 characters.'
   Max: 120

--- a/config/scss-lint.yml
+++ b/config/scss-lint.yml
@@ -5,3 +5,6 @@ linters:
     enabled: true
     allow_leading_underscore: true
     convention: "[^A-Z]"
+
+  StringQuotes:
+    style: double_quotes

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,9 +2,9 @@ FactoryGirl.define do
   factory :user do
     email
 
-    full_name 'John Smith'
-    password '123456'
-    password_confirmation '123456'
+    full_name "John Smith"
+    password "123456"
+    password_confirmation "123456"
   end
 
   trait :confirmed do

--- a/spec/features/user/manage_account/cancel_account_spec.rb
+++ b/spec/features/user/manage_account/cancel_account_spec.rb
@@ -1,22 +1,22 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Cancel account' do
+feature "Cancel account" do
   let(:user) { create :user, :confirmed }
 
   before(:each) do
-    sign_in(user.email, '123456')
+    sign_in(user.email, "123456")
   end
 
-  scenario 'I cancel my account' do
+  scenario "I cancel my account" do
     visit edit_user_registration_path(user)
-    click_link 'Cancel my account'
+    click_link "Cancel my account"
 
-    expect(page).to have_content('Sign in')
-    expect(page).to have_content('Bye! Your account has been successfully cancelled. We hope to see you again soon.')
+    expect(page).to have_content("Sign in")
+    expect(page).to have_content("Bye! Your account has been successfully cancelled. We hope to see you again soon.")
 
     visit new_user_session_path
-    sign_in(user.email, '123456')
+    sign_in(user.email, "123456")
 
-    expect(page).to have_content('Invalid email or password.')
+    expect(page).to have_content("Invalid email or password.")
   end
 end

--- a/spec/features/user/manage_account/update_account_spec.rb
+++ b/spec/features/user/manage_account/update_account_spec.rb
@@ -1,32 +1,32 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Update account with valid data' do
+feature "Update account with valid data" do
   let(:user) { create :user, :confirmed }
 
   before(:each) do
-    sign_in(user.email, '123456')
+    sign_in(user.email, "123456")
     visit edit_user_registration_path(user)
   end
 
-  scenario 'I submit update account form with valid data' do
+  scenario "I submit update account form with valid data" do
     fill_form_and_submit(
       :user,
       :edit,
-      full_name: 'New Name',
-      current_password: '123456'
+      full_name: "New Name",
+      current_password: "123456"
     )
 
-    expect(page).to have_content('New Name')
+    expect(page).to have_content("New Name")
   end
 
-  scenario 'Wrong current password' do
+  scenario "Wrong current password" do
     fill_form_and_submit(
       :user,
       :edit,
-      full_name: 'New Name',
-      current_password: 'wrong'
+      full_name: "New Name",
+      current_password: "wrong"
     )
 
-    expect(page).to have_content('is invalid')
+    expect(page).to have_content("is invalid")
   end
 end

--- a/spec/features/visitor/sign_in/sign_in_spec.rb
+++ b/spec/features/visitor/sign_in/sign_in_spec.rb
@@ -1,36 +1,36 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Sign in' do
+feature "Sign in" do
   let(:user) { create :user, :confirmed }
   let(:not_confirmed_user) { create :user, :not_confirmed }
 
-  scenario 'User signs in successfully' do
-    sign_in(user.email, '123456')
+  scenario "User signs in successfully" do
+    sign_in(user.email, "123456")
 
-    expect(page).to have_content('Sign out')
+    expect(page).to have_content("Sign out")
   end
 
-  scenario 'User signs in with invalid credentials' do
-    sign_in(user.email, 'wrong password')
+  scenario "User signs in with invalid credentials" do
+    sign_in(user.email, "wrong password")
 
-    expect(page).to have_content('Sign in')
+    expect(page).to have_content("Sign in")
   end
 
-  scenario 'User has not confirmed email address' do
-    sign_in(not_confirmed_user.email, '123456')
+  scenario "User has not confirmed email address" do
+    sign_in(not_confirmed_user.email, "123456")
 
-    expect(page).to have_content('You have to confirm your email address before continuing.')
+    expect(page).to have_content("You have to confirm your email address before continuing.")
   end
 
-  scenario 'User forgets his password' do
+  scenario "User forgets his password" do
     visit new_user_password_path
 
-    fill_in 'user_email', with: user.email
-    click_button 'Send me reset password instructions'
+    fill_in "user_email", with: user.email
+    click_button "Send me reset password instructions"
 
     open_email(user.email)
 
-    expect(current_email).to have_subject 'Reset password instructions'
+    expect(current_email).to have_subject "Reset password instructions"
     expect(current_email).to have_body_text(user.full_name)
   end
 end

--- a/spec/features/visitor/sign_in/sign_out_spec.rb
+++ b/spec/features/visitor/sign_in/sign_out_spec.rb
@@ -1,15 +1,15 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Sign out' do
+feature "Sign out" do
   let(:user) { create :user, :confirmed }
 
   before(:each) do
-    sign_in(user.email, '123456')
+    sign_in(user.email, "123456")
   end
 
-  scenario 'Logged in user signs out' do
-    click_link 'Sign out'
+  scenario "Logged in user signs out" do
+    click_link "Sign out"
 
-    expect(page).to have_content('Sign in')
+    expect(page).to have_content("Sign in")
   end
 end

--- a/spec/features/visitor/sign_up/sign_up_spec.rb
+++ b/spec/features/visitor/sign_up/sign_up_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Sign up' do
+feature "Sign up" do
   let(:user) { User.first }
   let(:user_attributes) { attributes_for(:user).slice(:full_name, :email, :password, :password_confirmation) }
 
@@ -9,32 +9,32 @@ feature 'Sign up' do
 
     fill_form(:user, user_attributes)
 
-    click_button 'Sign up'
+    click_button "Sign up"
   end
 
-  scenario 'User signs up successfully' do
+  scenario "User signs up successfully" do
     open_email(user.email)
 
-    expect(current_email).to have_subject 'Confirmation instructions'
+    expect(current_email).to have_subject "Confirmation instructions"
     expect(current_email).to have_body_text(user.full_name)
   end
 
-  scenario 'User confirms account' do
+  scenario "User confirms account" do
     open_email(user.email)
-    visit_in_email 'Confirm my account'
+    visit_in_email "Confirm my account"
 
     expect(page).to have_text(user.email)
   end
 
-  scenario 'User resents email confirmation instructions' do
+  scenario "User resents email confirmation instructions" do
     visit new_user_confirmation_path
 
-    fill_in 'user_email', with: user.email
-    click_button 'Resend confirmation instructions'
+    fill_in "user_email", with: user.email
+    click_button "Resend confirmation instructions"
 
     open_email(user.email)
 
-    expect(current_email).to have_subject 'Confirmation instructions'
+    expect(current_email).to have_subject "Confirmation instructions"
     expect(current_email).to have_body_text(user.full_name)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe User do
   it { is_expected.to validate_presence_of :full_name }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,17 +1,17 @@
-ENV['RAILS_ENV'] ||= 'test'
+ENV["RAILS_ENV"] ||= "test"
 
-require 'spec_helper'
-require File.expand_path('../../config/environment', __FILE__)
-require 'rspec/rails'
-require 'shoulda/matchers'
+require "spec_helper"
+require File.expand_path("../../config/environment", __FILE__)
+require "rspec/rails"
+require "shoulda/matchers"
 
 # Run codeclimate-test-reporter only in CI
-if ENV['CI']
-  require 'codeclimate-test-reporter'
+if ENV["CI"]
+  require "codeclimate-test-reporter"
   CodeClimate::TestReporter.start
 end
 
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false

--- a/spec/support/devise_helpers.rb
+++ b/spec/support/devise_helpers.rb
@@ -2,7 +2,7 @@ module DeviseHelpers
   def sign_in(email, password)
     visit new_user_session_path
 
-    click_link 'Sign in'
+    click_link "Sign in"
 
     fill_form(
       :user,
@@ -10,6 +10,6 @@ module DeviseHelpers
       password: password
     )
 
-    click_button 'Sign in'
+    click_button "Sign in"
   end
 end


### PR DESCRIPTION
Using double quotes in Ruby and CoffeeScript will reduce the number of changes we have to make when a string transitions into something that needs interpolation or escaped characters:

* `"Isn't this nice?"`
* `"It is #{nice}"`
* `"[data-behavour='exceprt']"`

This will also make our code consistent: _all_ strings will now have double quotes regardless of their content.

In order to be completely consistent and not to have different conventions we should also force the same rule in SCSS.
