### PR TITLE
Drop username and password from config/database.yml

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -3,8 +3,6 @@
 defaults_development: &defaults_development
   adapter: postgresql
   encoding: unicode
-  username: postgres
-  password: postgres
   host: localhost
 
 development:


### PR DESCRIPTION
You don't have to predefine credentials on `config/database.yml` since a freshly initialized system always contains one predefined user. This user will have the fixed ID 1, and by default (unless altered when running initdb) it will have the same name as the operating system user that initialized the database cluster.

So you should be able to log in into postgresql without passing any credentials info, either from console or from rails app.

```bash
psql -d postgres
```