### PR TITLE
Introduce Coffeelint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add [Coffeelint](https://github.com/zmbush/coffeelint-ruby) to keep Coffeescript code clean and consistent
 - Force double quotes everywhere: SCSS, Ruby. For more details see: https://github.com/fs/rails-base/pull/274
 - Add [SCSS-Lint](https://github.com/brigade/scss-lint) for reporting violations of SCSS coding conventions
 - Style Kaminari pagination to make it look like [Foundation's pagination](http://foundation.zurb.com/docs/v/4.3.2/components/pagination.html)

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test do
   gem "brakeman", require: false
   gem "bundler-audit"
   gem "byebug"
+  gem "coffeelint"
   gem "dotenv-rails"
   gem "factory_girl_rails"
   gem "fuubar", "~> 2.0.0.rc1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    coffeelint (1.9.1)
+      coffee-script
+      execjs
+      json
     colored (1.2)
     columnize (0.8.9)
     crack (0.4.2)
@@ -365,6 +369,7 @@ DEPENDENCIES
   capybara-webkit
   codeclimate-test-reporter
   coffee-rails
+  coffeelint
   database_cleaner
   decent_exposure
   devise

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It's based on Rails 4 and Ruby 2.2.2.
 * [Web Console](https://github.com/rails/web-console) for better debugging via
   in-browser IRB consoles
 * [SCSS-Lint](https://github.com/brigade/scss-lint) for reporting violations of SCSS coding conventions
+* [Coffeelint](https://github.com/clutchski/coffeelint) to keep Coffeescript code clean and consistent
 
 ## Testing Gems
 

--- a/bin/quality
+++ b/bin/quality
@@ -5,6 +5,10 @@ set -e
 bin/rubocop --config config/rubocop.yml
 bin/brakeman --quiet --skip-libs --exit-on-warn
 bin/rails_best_practices --silent --spec --features -x lib/templates, config
+
+# Using rake-task here since coffeelint.rb cmd doesn't exit with non-zero status
+# when code contains errors
+bin/rake coffeelint
 bin/scss-lint --config config/scss-lint.yml
 
 bin/bundle-audit update

--- a/config/coffeelint.json
+++ b/config/coffeelint.json
@@ -1,0 +1,19 @@
+{
+  "arrow_spacing": "error",
+  "camel_case_classes": "error",
+  "duplicate_key": "error",
+  "max_line_length": {
+    "value": "120",
+    "level": "error"
+  },
+  "missing_fat_arrows": "error",
+  "newlines_after_classes": "error",
+  "no_backticks": "error",
+  "no_stand_alone_at": "error",
+  "no_tabs": "error",
+  "no_trailing_semicolons": "error",
+  "no_trailing_whitespace": "error",
+  "no_unnecessary_fat_arrows": "error",
+  "non_empty_constructor_needs_parens": "error",
+  "space_operators": "error"
+}


### PR DESCRIPTION
In addition to linting SCSS it'd be great to also lint CoffeeScript. While `coffeelint` is not good at detecting terribly awful code like:

```coffee
constructor: (@form, options) ->
  do @init

init: =>
  do @bind_events

bind_events: =>
  @form.on 'submit', @submit
```

It will still help us to write _consistent_ CoffeeScript code. So, IMO, it worth adding to build process.