### PR TITLE
Fix unexpected devise titles changes

### DIFF
--- a/app/views/users/confirmations/new.html.slim
+++ b/app/views/users/confirmations/new.html.slim
@@ -1,6 +1,6 @@
 .row
   .columns
-    h2 = title
+    h2 = t('titles.devise.confirmations.new')
 
 .row
   .medium-6.columns

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -1,6 +1,6 @@
 .row
   .columns
-    h2 = title
+    h2 = t('titles.devise.passwords.edit')
 
 .row
   .medium-6.columns
@@ -17,7 +17,7 @@
         = f.input :password_confirmation, required: true
 
       .form-actions
-        = f.button :submit
+        = f.button :submit, 'Update password'
 
   .medium-6.columns.end
     = render 'users/shared/links'

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -1,6 +1,6 @@
 .row
   .columns
-    h2 = title
+    h2 = t('titles.devise.passwords.new')
 
 .row
   .medium-6.columns

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,6 +1,6 @@
 .row
   .columns
-    h2 = title
+    h2 = t('titles.devise.registrations.new')
 
 .row
   .medium-6.columns


### PR DESCRIPTION
I've found unexpected behaviour on sign up, reset password, edit password, resend confirmation pages.

When I submit the form, titles &buttons are changing. Some screens:
http://take.ms/6qmL9
http://take.ms/3Vv5e
http://take.ms/5Jy9t
http://take.ms/yL3Qy

@timurvafin @vast could we do it in rails best practices way and keep only  = title ?
