### PR TITLE
Allow rails_best_practices gem to use config file at /config dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Deprecate using i18n for submits, see: https://github.com/fs/rails-base/commit/ed4e55992e671cb3c9281cd10a4f5c26e7f1c02d
 - Fix wrong titles and submit labels on devise pages after submit
+- Fix `rails_best_practices` invocation from `bin/quality`, `config/rails_best_practices.yml` was ignored before.
 - Introduce [CSSComb](https://github.com/csscomb/csscomb.js). For more details see: https://github.com/fs/rails-base/pull/284
 - Add `Brewfile` to track application dependencies.
 

--- a/bin/quality
+++ b/bin/quality
@@ -4,7 +4,7 @@ set -e
 
 bin/rubocop --config config/rubocop.yml
 bin/brakeman --quiet --skip-libs --exit-on-warn
-bin/rails_best_practices --silent --spec --features -x lib/templates, config
+bin/rails_best_practices --silent --spec --features -x lib/templates
 
 # Using rake-task here since coffeelint.rb cmd doesn't exit with non-zero status
 # when code contains errors


### PR DESCRIPTION
When we exclude 'config' dir from check only default config will be used