### PR TITLE
More cops

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -11,6 +11,12 @@ Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
 
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+
+Style/CollectionMethods:
+  Enabled: true
+
 Style/SymbolArray:
   Description: 'Use %i or %I for arrays of symbols.'
   Enabled: true


### PR DESCRIPTION
Enabled two cops [disabled by default](https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml):

1. https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
2. https://github.com/bbatsov/ruby-style-guide#single-line-blocks

Unfortunately there are no cops (and it's almost impossible to create them) for other style issues which we noticed recently. We can force them as text in our internal styleguide.

<hr />

While it's cool than you can use backslash (`\`) and keep each argument on its own line, such indentation results in a bunch of short lines. It's hard to read as your eyes have to jump bottom after each word.

```ruby
# bad
delegate \
  :areas,
  :cuisines,
  :features,
  :max_price,
  :sorting,
  :city,
  to: :filter

# good
delegate :areas, :cuisines, :features, :max_price, :sorting, :city,
  to: :filter
```

<hr />

Ruby Style Guide [says on parentheses](https://github.com/bbatsov/ruby-style-guide#no-dsl-parens):

> Omit parentheses around parameters for methods that are part of an internal DSL (e.g. Rake, Rails, RSpec), methods that have "keyword" status in Ruby (e.g. `attr_reader`, `puts`) and attribute access methods. Use parentheses around the arguments of all other method invocations.

```ruby
# bad
# `have_content` is not a part of Capybara DSL, it's a custom matcher
expect(page).to have_content first_city.title
# `fill_in` is a part of Capybara DSL along with `select`, `within`, `click_on`, `click_button`, `click_link`
fill_in(:foo, :with => "Bar") 

# good
expect(page).to have_content(first_city.title)
fill_in :foo, :with => "Bar"
```

```ruby
# bad
def collection_resource
  order_collection includes_related_collections super
end

# good
def collection_resource
  order_collection(includes_related_collections(super))
end
```

