### PR TITLE
Introduce global `currentUser` object to JS environment

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -7,6 +7,7 @@
 #= require jquery
 #= require jquery_ujs
 #= require foundation
+#= require current_user
 #= require skim
 #= require_tree ../templates
 #= require_tree .

--- a/app/assets/javascripts/current_user.coffee
+++ b/app/assets/javascripts/current_user.coffee
@@ -1,0 +1,10 @@
+class User
+  constructor: (@data = {}) ->
+
+  get: (param) ->
+    @data[param]
+
+  isSignedIn: ->
+    @get("id")?
+
+App.currentUser = new User(App.currentUserData)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,11 +10,11 @@ html class='no-js' lang='en'
 
     = csrf_meta_tags
 
-    /! Le styles
     = stylesheet_link_tag :application
 
-    /! Le modernizr
     = javascript_include_tag 'vendor/modernizr'
+
+    = javascript_tag 'window.App = {}'
 
     == analytics_init if GA.tracker
 
@@ -26,5 +26,8 @@ html class='no-js' lang='en'
       = yield
 
     = render 'footer'
+
+    javascript:
+      App.currentUserData = #{raw current_user.to_json};
 
     = javascript_include_tag :application


### PR DESCRIPTION
Instead of relying on something visible only for authenticated user in DOM (which is ugly and fragile):

```coffee
if $('.current_user:first').size()
  @sendRating(value)
```

we should hide implementation details and use global `currentUser` object. `currentUser` is set up from JSON data in application layout. With it example above would look like:

```coffee
if App.currentUser.isSignedIn()
  @sendRating(value)
```

This PR also shows how to properly pass any global backend variables to client-side. For example, [flipper](https://github.com/jnunemaker/flipper) feature toggles could look like:

```slim
javascript:
  App.currentUserData = #{raw current_user.to_json};
  App.$flipper = #{raw js_feature_toggles };
```

```ruby
def js_feature_toggles
  features_state = $flipper.features.map do |feature|
    [feature.name, $flipper[feature.name].enabled?]
  end

  Hash[features_state].to_json
end
```

```coffee
# initialize ckeditor support only if this feature is toggled on
if App.$flipper.ckeditor 
  @$("textarea").ckeditor()
```