### PR TITLE
Move CanonicalHost and Auth::Basic configuration to initializers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ SECRET_KEY_BASE=development_secret
 # ROLLBAR_KEY=your_key_here
 
 # enable basic auth to close the app from unauthorized viewers:
+# AUTH_BASIC_REALM=your_application_name
 # AUTH_BASIC_PASS=your_password_here
 
 # set single hostname:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Move Rack::CanonicalHost and Rack::Auth::Basic configuration to initializers
 - Support [Heroku Review Apps](https://devcenter.heroku.com/articles/github-integration#review-apps)
 - Update [rails](https://github.com/rails/rails) version up to 4.2.3
 - Add [Rails ERD](https://github.com/voormedia/rails-erd) gem for generating a diagram based on application's AR models

--- a/config.ru
+++ b/config.ru
@@ -1,11 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path("../config/environment",  __FILE__)
-use Rack::CanonicalHost, ENV["CANONICAL_HOST"] if ENV["CANONICAL_HOST"]
-
-# Require authentication if password is set
-use Rack::Auth::Basic, "RailsBase" do |_, password|
-  ENV["AUTH_BASIC_PASS"] == password
-end if ENV["AUTH_BASIC_PASS"]
-
 run Rails.application

--- a/config/initializers/auth_basic.rb
+++ b/config/initializers/auth_basic.rb
@@ -1,0 +1,7 @@
+# Require authentication if password is set
+if ENV["AUTH_BASIC_PASS"]
+  realm = ENV.fetch("AUTH_BASIC_REALM", Rails.application.class.to_s.deconstantize.titleize)
+  Rails.application.config.middleware.use Rack::Auth::Basic, realm do |_, password|
+    ENV["AUTH_BASIC_PASS"] == password
+  end
+end

--- a/config/initializers/canonical_host.rb
+++ b/config/initializers/canonical_host.rb
@@ -1,0 +1,2 @@
+# Ensure requests are only served from one, canonical host name
+Rails.application.config.middleware.use Rack::CanonicalHost, ENV["CANONICAL_HOST"] if ENV["CANONICAL_HOST"]


### PR DESCRIPTION
Add initializers to configure middlewares:
* `config/initializers/canonical_host.rb` - `Rack::CanonicalHost`
* `config/initializers/auth_basic.rb` - `Rack::Auth::Basic`