### PR TITLE
Add app.json to enable Heroku Review Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
+- Support [Heroku Review Apps](https://devcenter.heroku.com/articles/github-integration#review-apps)
 - Update [rails](https://github.com/rails/rails) version up to 4.2.3
-
 - Add [Rails ERD](https://github.com/voormedia/rails-erd) gem for generating a diagram based on application's AR models
 
 ## 1.5 - 2015-08-14

--- a/app.json
+++ b/app.json
@@ -1,0 +1,17 @@
+{
+  "name": "rails-base",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:setup"
+  },
+  "env": {
+    "LANG": { "required": true },
+    "RACK_ENV": { "required": true },
+    "RAILS_ENV": { "required": true },
+    "RAILS_SERVE_STATIC_FILES": { "required": true },
+    "SECRET_KEY_BASE": { "generator": "secret" }
+  },
+  "addons": [
+    "heroku-postgresql",
+    "sendgrid"
+  ]
+}


### PR DESCRIPTION
Heroku could create separate application per each pull request.
Environment variables and add-ons will be generated based on app.json.

https://devcenter.heroku.com/articles/github-integration#review-apps