### PR TITLE
Add ability to specify custom asset_host via ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Specify assets server host name, eg.: http://d2oek0c5zwe48d.cloudfront.net
+ASSET_HOST=http://locahost:5000
+
 # current environment:
 RACK_ENV=development
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  config.action_controller.asset_host = ENV.fetch("ASSET_HOST")
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.version = ENV.fetch("ASSETS_VERSION", "1.0")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
* `ENV["ASSET_HOST"]`, ex.: http://d2oek0c5zwe48d.cloudfront.net
* `ENV["ASSETS_VERSION"]`, by default "1.0"

https://devcenter.heroku.com/articles/using-amazon-cloudfront-cdn#amazon-cloudfront