### PR TITLE
Make ASSET_HOST optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# Specify assets server host name, eg.: http://d2oek0c5zwe48d.cloudfront.net
-ASSET_HOST=http://locahost:5000
+# Specify assets server host name, eg.: d2oek0c5zwe48d.cloudfront.net
+# ASSET_HOST=d2oek0c5zwe48d.cloudfront.net
 
 # current environment:
 RACK_ENV=development

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV.fetch("ASSET_HOST")
+  config.action_controller.asset_host = ENV["ASSET_HOST"] if ENV["ASSET_HOST"]
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
In development mode `config.action_controller.asset_host` could be skipped,
so no need to setup `ASSET_HOST` as `localhost:500`.