### PR TITLE
Update Uglifier gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update [Uglifier](https://github.com/lautis/uglifier) version up to 2.7.2
 - Add [Rubocop-Rspec](https://github.com/nevir/rubocop-rspec) for reporting violations of Ruby style guide in specs
 - Add [Slim-Lint](https://github.com/sds/slim-lint) for reporting violations of Ruby style guide in `.slim` templates
 - Update Ruby to 2.2.3

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "jquery-rails"
 gem "sass-rails", "~> 5.0.0"
 gem "skim", git: "https://github.com/jfirebaugh/skim"
 gem "therubyracer", platforms: :ruby
-gem "uglifier", ">= 1.3.0"
+gem "uglifier", ">= 2.7.2"
 
 # views
 gem "active_link_to"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,7 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.4.0)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uniform_notifier (1.9.0)
@@ -443,7 +443,7 @@ DEPENDENCIES
   spring-commands-rspec
   therubyracer
   thin
-  uglifier (>= 1.3.0)
+  uglifier (>= 2.7.2)
   web-console (~> 2.0)
   webmock
 


### PR DESCRIPTION
Due to UglifyJS vulnerability [uglifier](https://github.com/lautis/uglifier) should be updated.
Details: https://github.com/rubysec/ruby-advisory-db/pull/202