### PR TITLE
Disable simple form i18n lookup for hints and placeholders by default

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,9 @@
     "postdeploy": "bundle exec rake db:setup"
   },
   "env": {
+    "HOST": { "required": true },
     "LANG": { "required": true },
+    "MAILER_SENDER_ADDRESS": { "required": true },
     "RACK_ENV": { "required": true },
     "RAILS_ENV": { "required": true },
     "RAILS_SERVE_STATIC_FILES": { "required": true },

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -14,11 +14,13 @@
         = f.input :email, required: true
         = f.input :password,
             autocomplete: "off",
-            required: false
+            required: false,
+            hint: true
         = f.input :password_confirmation,
             required: false
         = f.input :current_password,
-            required: true
+            required: true,
+            hint: true
 
       .form-actions
         = f.button :submit, "Update"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -17,7 +17,7 @@
 
       .form-inputs
         = f.input :email, required: false, autofocus: true
-        = f.input :password, required: false
+        = f.input :password, required: false, hint: true
         = f.input :remember_me, as: :boolean
 
       .form-actions

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -51,7 +51,7 @@ SimpleForm.setup do |config|
 
   config.wrappers :foundation, class: :input, hint_class: "has-hint", error_class: :error do |b|
     b.use :html5
-    b.use :placeholder
+    b.optional :placeholder
     b.use :label
 
     b.optional :maxlength
@@ -64,12 +64,12 @@ SimpleForm.setup do |config|
 
     # Uncomment the following line to enable hints. The line is commented out by default since Foundation
     # does't provide styles for hints. You will need to provide your own CSS styles for hints.
-    b.use :hint,  wrap_with: { tag: :small, class: :hint }
+    b.optional :hint,  wrap_with: { tag: :small, class: :hint }
   end
 
   config.wrappers :with_labels, class: :row, hint_class: "has-hint", error_class: :error do |b|
     b.use :html5
-    b.use :placeholder
+    b.optional :placeholder
 
     b.optional :maxlength
     b.optional :pattern

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -12,11 +12,17 @@ en:
       default_message: 'Please review the problems below:'
     labels:
       user:
+        full_name: Full name
         new:
           email: Enter your email address
+          password: Password
+          password_confirmation: Confirm password
+          remember_me: Remember me
         edit:
+          email: Email
           password: Enter new password
           password_confirmation: Confirm your new password
+          current_password: Current password
     hints:
       user:
         password: Leave it blank if you dont want to change it


### PR DESCRIPTION
Related to: #313 