### PR TITLE
Move Rack::MiniProfiler authorization to initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Move Rack::MiniProfiler authorization to initializers
 - Add ability to configure SMTP Mailer options not only with SendGrid via `config/initializers/mailer.rb`
 - [Remove `app_config`](https://github.com/fs/rails-base/pull/342) shortcut and use `ENV` exclusively
 - Turning on Partial Double Verification for Rspec

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "kaminari"
 gem "memory_profiler"
 gem "puma"
 gem "pundit"
-gem "rack-mini-profiler"
+gem "rack-mini-profiler", require: false
 gem "rack-canonical-host"
 gem "responders"
 gem "rollbar"

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,9 @@ module RailsBase
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
+    # Enable deflate / gzip compression of controller-generated responses
+    config.middleware.use Rack::Deflater
+
     # Set default From address for all Mailers
     config.action_mailer.default from: ENV.fetch("MAILER_SENDER_ADDRESS")
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,9 +27,6 @@ Rails.application.configure do
   # Set Cache Headers for static files to 1 year.
   config.static_cache_control = "public, max-age=#{1.year.to_i}"
 
-  # Enable deflate / gzip compression of controller-generated responses
-  config.middleware.use Rack::Deflater
-
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass

--- a/config/initializers/mini_profiler.rb
+++ b/config/initializers/mini_profiler.rb
@@ -1,8 +1,22 @@
-mini_profiler_ip_whitelist = ENV.fetch("MINI_PROFILER_IP_WHITELIST",  "").split(",")
+require "rack-mini-profiler"
 
+Rack::MiniProfilerRails.initialize!(Rails.application)
+
+# Make sure Deflater middleware works after MiniProfiler
+# https://github.com/MiniProfiler/rack-mini-profiler#custom-middleware-ordering-required-if-using-rackdeflate-with-rails
+Rails.application.middleware.delete(Rack::MiniProfiler)
+Rails.application.middleware.insert_after(Rack::Deflater, Rack::MiniProfiler)
+
+# We prefer MemoryStore
+Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemoryStore
+
+# Disable MiniProfiler by default, it could be enabled by query string "pp=enable"
+Rack::MiniProfiler.config.enabled = false
+
+# Configure authorization hook based on IP whitelist
+ip_whitelist = ENV.fetch("MINI_PROFILER_IP_WHITELIST",  "").split(",")
+Rack::MiniProfiler.config.authorization_mode = :allow_all
 Rack::MiniProfiler.config.pre_authorize_cb = lambda { |env|
   request = Rack::Request.new(env)
-  mini_profiler_ip_whitelist.include?(request.ip)
+  ip_whitelist.include?(request.ip)
 }
-
-Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemoryStore


### PR DESCRIPTION
Before Rack::MiniProfiler authorization step was performed in the
controller's before action. This commit moves it to initializer.

Also we disable MiniProfiler by default, it could be enabled with `pp=enable`
query string.

Bug in production environment fixed when MiniProfiler does not work with
Rack::Deflater.

https://github.com/MiniProfiler/rack-mini-profiler#custom-middleware-ordering-required-if-using-rackdeflate-with-rails