### PR TITLE
Use ROLLBAR_ACCESS_TOKEN instead of ROLLBAR_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ RAILS_SERVE_STATIC_FILES=true
 # DATABASE_NAME=paste_database_prefix_here
 
 # Set Rollbar key for the app
-# ROLLBAR_KEY=your_key_here
+# ROLLBAR_ACCESS_TOKEN=your_key_here
 
 # We send devise email using this "from" address
 MAILER_SENDER_ADDRESS=noreply@example.com

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,7 +1,7 @@
 require "rollbar/rails"
 
 Rollbar.configure do |config|
-  config.access_token = ENV["ROLLBAR_KEY"]
+  config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
 
   # Without configuration, Rollbar is enabled by in all environments.
   # To disable in specific environments, set config.enabled=false.


### PR DESCRIPTION
To be able to use Rollbar Heroku add-on out of the box `ROLLBAR_KEY`
renamed to `ROLLBAR_ACCESS_TOKEN`.