### PR TITLE
Upgrade nikogiri to close CVE-2015-1819

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     minitest (5.8.1)
     multi_json (1.11.0)
     newrelic_rpm (3.13.0.299)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     oj (2.12.14)
     orm_adapter (0.5.0)


### PR DESCRIPTION
Nokogiri gem contains several vulnerabilities in libxml2 and libxslt

https://github.com/sparklemotion/nokogiri/issues/1374