### PR TITLE
Release 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.7 - 2015-11-27
+
 - Introduce [Draper](https://github.com/drapergem/draper) for presenting models into views
 - Move Rack::MiniProfiler authorization to initializers
 - Add ability to configure SMTP Mailer options not only with SendGrid via `config/initializers/mailer.rb`


### PR DESCRIPTION
- Introduce [Draper](https://github.com/drapergem/draper) for presenting models into views
- Move Rack::MiniProfiler authorization to initializers
- Add ability to configure SMTP Mailer options not only with SendGrid via `config/initializers/mailer.rb`
- [Remove `app_config`](https://github.com/fs/rails-base/pull/342) shortcut and use `ENV` exclusively
- Turning on Partial Double Verification for Rspec
- Replace [rails_12factor](https://github.com/heroku/rails_12factor) with [rails_stdout_logging](https://github.com/heroku/rails_stdout_logging)
- Update [foundation-rails gem](https://github.com/zurb/foundation-rails)
- Update [rollbar gem](https://github.com/rollbar/rollbar-gem)
- Add gem [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) for displaying speed badge for every html page.
- Add configuration for [NewRelic](https://devcenter.heroku.com/articles/newrelic) Heroku-addon
- Implement the dynamic database name