### PR TITLE
Fix alerts dismiss button on iOs devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix alerts closing button on iOs devices
 - Update [simple_form gem](https://github.com/plataformatec/simple_form)
 - User factory generate confirmed user by default
 - Upgrade Ruby to 2.2.4

--- a/app/views/application/_messages.html.slim
+++ b/app/views/application/_messages.html.slim
@@ -1,4 +1,4 @@
 - flash.each do |type, content|
-  div(data-alert class="alert-box #{type}")
+  div(data-alert class="alert-box #{type}" tabindex="0" aria-live="assertive" role="alertdialog")
     = content
-    a.close &times;
+    button.close(tabindex="0" aria-label="Close Alert") &times;


### PR DESCRIPTION
According documentation (http://foundation.zurb.com/sites/docs/v/5.5.3/components/alert_boxes.html), Foundation alerts "close" button needs to have an `href` attribute. Without `href` it's normally works on desktops and some mobile devices, but on iOs Safari it matters and alerts won't closing.