### PR TITLE
fix flash messages and underfield hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Removed wrong underfield hint on sign_up page
+- Fix flash messages at new password and email confirmation sending
 - Install [health_check](https://github.com/ianheggie/health_check)
 - Fix alerts closing button on iOs devices
 - Update [simple_form gem](https://github.com/plataformatec/simple_form)

--- a/config/locales/flash.en.yml
+++ b/config/locales/flash.en.yml
@@ -1,5 +1,14 @@
 en:
   flash:
+    devise:
+      passwords:
+        create:
+          alert: "Password could not be sent."
+        update:
+          alert: "Password could not be updated."
+      confirmations:
+        create:
+          alert: "Confirmations could not be sent"
     actions:
       create:
         notice: '%{resource_name} was successfully created.'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -19,6 +19,6 @@ en:
           password_confirmation: Confirm your new password
     hints:
       user:
-        password: Leave it blank if you dont want to change it
-        current_password: We need your current password to confirm your changes
-
+        edit:
+          password: Leave it blank if you dont want to change it
+          current_password: We need your current password to confirm your changes


### PR DESCRIPTION
Pull Request to solve issue#404 + wrong underfield hints on sign_up page

One thing left unfixed: after redirecting from user's mail to new password creating page we still see hint "Leave it blank if you dont want to change it"