### PR TITLE
Show slowest specs through "profile_examples" option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --colour
 --format <%= ENV['CI'] ? 'progress' : 'Fuubar' %>
 --require spec_helper
+--profile


### PR DESCRIPTION
Show slowest 10 specs (with path and consumed time)
Read more about [profile_examples](https://www.relishapp.com/rspec/rspec-core/docs/configuration/profile-examples) option