### PR TITLE
Make sure decorated models respond to `to_model`

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,4 +1,6 @@
 class ApplicationDecorator < Draper::Decorator
+  delegate :to_model
+
   def self.collection_decorator_class
     PaginatingDecorator
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -3,6 +3,6 @@ class ApplicationPolicy
 
   def initialize(user, record)
     @user = user
-    @record = record
+    @record = record.to_model
   end
 end


### PR DESCRIPTION
To make sure we support url helpers we need to delegate
`to_model` to original object.

In form we will use `user.to_model` manually while this PR not merged
https://github.com/plataformatec/simple_form/pull/1256

Also make sure we use original object in policy object.