### PR TITLE
update safe-yaml gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.6.6)
       sexp_processor (~> 4.1)
-    safe_yaml (1.0.1)
+    safe_yaml (1.0.4)
     sass (3.4.18)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)


### PR DESCRIPTION
when we try to use webmock we get next error:
```
require 'webmock/rspec'
NameError: uninitialized constant Syck
from /Users/artembiserov/src/open-source/rails-base/.bundle/ruby/2.2.0/gems/safe_yaml-1.0.1/lib/safe_yaml/syck_node_monkeypatch.rb:42:in `<top (required)>'
```