### PR TITLE
Fix misspelling of company name in footer

### DIFF
--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -1,3 +1,3 @@
 footer.row
   .columns
-    p &copy; FlatStack #{Time.zone.today.year}
+    p &copy; Flatstack #{Time.zone.today.year}


### PR DESCRIPTION
As Timur said correct spelling will be Flatstack not FlatStack