### PR TITLE
Remove shoulda matchers gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove Shoulda Matchers
+
 ## 1.8 - 2016-03-22
 
 - Upgrade Rails to 4.2.6, Ruby to 2.3.0, Rollbar to 2.8.3, Spring to 1.6.4

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ group :test do
   gem "email_spec"
   gem "formulaic"
   gem "launchy"
-  gem "shoulda-matchers", require: false
   gem "webmock", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,8 +319,6 @@ GEM
       sass (~> 3.4.1)
     seedbank (0.3.0)
     sexp_processor (4.5.1)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
@@ -444,7 +442,6 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   scss_lint
   seedbank
-  shoulda-matchers
   simple_form
   skim
   slim

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-describe User do
-  it { is_expected.to validate_presence_of :full_name }
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,6 @@ ENV["RAILS_ENV"] ||= "test"
 require "spec_helper"
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
-require "shoulda/matchers"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
There are just unused matchers, which check common rails methods
@VladimirMikhailov @ArturMinnullin please, provide your opinion