### PR TITLE
Fix flaky specs based on encoded html entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix flaky specs based on encoded user's full_name
+
 ## 1.9 - 2016-04-22
 
 - Introduce [Rspec-Its](https://github.com/rspec/rspec-its)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :user do
     email
-    full_name { Faker::Name.name }
+    full_name { Faker::Internet.user_name }
     password "123456"
     password_confirmation { password }
     confirmed_at 1.hour.ago


### PR DESCRIPTION
Issue: When `'` becomes `&#39;` on text comparisons:
```ruby
expected the body to contain "Jermain O'Keefe" but was "<p>Jermain O&#39;Keefe!</p>
```
Solution: using another `Faker`'s method, which generates string without special chars.

---
Discussed in this PR: https://github.com/fs/rails-base/pull/411