### PR TITLE
Configure .gitattributes to avoid merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Configure `.gitattributes` to avoid merge conflicts due to `CHANGELOG`
+
 ## 1.8 - 2016-03-22
 
 - Upgrade Rails to 4.2.6, Ruby to 2.3.0, Rollbar to 2.8.3, Spring to 1.6.4


### PR DESCRIPTION
 Instead of leaving conflicts the union merge option will resolve conflicts favouring both side of the lines.