### PR TITLE
Update rspec core to 3.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.1.1)
+    rake (11.1.2)
     rake-compiler (0.9.5)
       rake
     ref (1.0.5)
@@ -273,7 +273,7 @@ GEM
       railties (>= 4.2.0, < 5.1)
     rollbar (2.8.3)
       multi_json
-    rspec-core (3.4.3)
+    rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)


### PR DESCRIPTION
update rspec-core to 3.4.5 to prevent next warning:
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.