### PR TITLE
Allow users to edit their account without providing a current password

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,9 @@
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    protected
+
+    def update_resource(resource, params)
+      resource.update_without_password(params)
+    end
+  end
+end

--- a/app/sanitizers/user/parameter_sanitizer.rb
+++ b/app/sanitizers/user/parameter_sanitizer.rb
@@ -12,7 +12,7 @@ class User
     end
 
     def account_update
-      default_params.permit(USER_PARAMS, :current_password)
+      default_params.permit(USER_PARAMS)
     end
   end
 end

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -17,8 +17,6 @@
             required: false
         = f.input :password_confirmation,
             required: false
-        = f.input :current_password,
-            required: true
 
       .form-actions
         = f.button :submit, "Update"

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -28,6 +28,7 @@ RemoveTrailingWhitespaceCheck: { }
 RemoveUnusedMethodsInControllersCheck:
   except_methods:
   - ApplicationController#devise_parameter_sanitizer
+  - Users::RegistrationsController#update_resource
 RemoveUnusedMethodsInHelpersCheck: { except_methods: [] }
 RemoveUnusedMethodsInModelsCheck: { except_methods: [] }
 ReplaceComplexCreationWithFactoryMethodCheck: { attribute_assignment_count: 2 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "users/registrations" }
   root to: "pages#home"
 end

--- a/spec/features/user/account/update_spec.rb
+++ b/spec/features/user/account/update_spec.rb
@@ -8,16 +8,9 @@ feature "Update Account" do
   end
 
   scenario "User updates account with valid data" do
-    fill_form(:user, full_name: "New Name", current_password: current_user.password)
+    fill_form(:user, full_name: "New Name")
     click_on "Update"
 
     expect(page).to have_content("New Name")
-  end
-
-  scenario "User updates account with invalid password" do
-    fill_form(:user, full_name: "New Name", current_password: "wrong")
-    click_on "Update"
-
-    expect(page).to have_content("is invalid")
   end
 end


### PR DESCRIPTION
Suggestion is to skip password confirmation because this feature is a little bit non-obvious and sometimes even those users who knows about it forget to input current password before hitting the update button.