### PR TITLE
Replace sass-rails with sassc-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Replace sass-rails with [sassc-rails](https://github.com/sass/sassc-rails) based on libsaas
 - Update [nokogiri gem](https://github.com/sparklemotion/nokogiri)
 - Update [rails_best_practices gem](https://github.com/railsbp/rails_best_practices)
 - Update [email_spec gem](https://github.com/email-spec/email-spec) to avoid flaky specs based on encoded html entities

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "coffee-rails"
 gem "foundation-icons-sass-rails"
 gem "foundation-rails"
 gem "jquery-rails"
-gem "sass-rails", "~> 5.0.0"
+gem "sassc-rails"
 gem "skim"
 gem "therubyracer", platforms: :ruby
 gem "uglifier", ">= 2.7.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
     fast_stack (0.1.0)
       rake
       rake-compiler
+    ffi (1.9.13)
     flamegraph (0.1.0)
       fast_stack
     foreman (0.63.0)
@@ -292,6 +293,17 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
+    sassc (1.10.0)
+      bundler
+      ffi (~> 1.9.6)
+      sass (>= 3.3.0)
+    sassc-rails (1.2.1)
+      railties (>= 4.0.0)
+      sass
+      sassc (~> 1.9)
+      sprockets (> 2.11)
+      sprockets-rails
+      tilt
     scss_lint (0.48.0)
       rake (>= 0.9, < 12)
       sass (~> 3.4.15)
@@ -423,7 +435,7 @@ DEPENDENCIES
   rspec-rails (~> 3.4)
   rubocop
   rubocop-rspec
-  sass-rails (~> 5.0.0)
+  sassc-rails
   scss_lint
   seedbank
   shoulda-matchers
@@ -439,6 +451,9 @@ DEPENDENCIES
   uglifier (>= 2.7.2)
   web-console (~> 2.0)
   webmock
+
+RUBY VERSION
+   ruby 2.3.0p0
 
 BUNDLED WITH
    1.12.5

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's based on Rails 4 and Ruby 2.3.0.
 
 ## Application Gems
 
-* [Sass](https://github.com/rails/sass-rails) for Sass/Scss stylesheets
+* [SassC](https://github.com/sass/sassc-rails) for Sass/Scss stylesheets
 * [Zurb Foundation](https://github.com/zurb/foundation-rails) as CSS framework.
   For more information see [documentation on using Foundation in Rails apps](http://foundation.zurb.com/docs/applications.html)
 * [Foundation Icon Font](https://github.com/zaiste/foundation-icons-sass-rails) for icons. Browse [icon set](http://zurb.com/playground/foundation-icon-fonts-3) examples

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,12 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  # Turn on inline source maps
+  config.sass.inline_source_maps = true
+
+  # Disable line comments
+  config.sass.line_comments = false
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
This should essentially be a drop in alternative to sass-rails based in [LibSass](https://github.com/sass/libsass). In one larger project, this made compilation 4x faster.
