### PR TITLE
Upgrade rack-mini-profiler to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Upgrade [rack-mini-profiler gem](https://github.com/MiniProfiler/rack-mini-profiler) to 0.10.1 to avoid [vulnerability](https://github.com/MiniProfiler/rack-mini-profiler/commit/4273771d65f1a7411e3ef5843329308d0e2d257c)
 - Minor improvements in newrelick.yml
 - Update Ruby to 2.3.1
 - Update bin/setup script to clean old log files and tmp directory

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,8 +210,8 @@ GEM
     rack-canonical-host (0.2.1)
       addressable (> 0, < 3)
       rack (>= 1.0.0, < 3)
-    rack-mini-profiler (0.9.7)
-      rack (>= 1.1.3)
+    rack-mini-profiler (0.10.1)
+      rack (>= 1.2.0)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -439,6 +439,9 @@ DEPENDENCIES
   uglifier (>= 2.7.2)
   web-console (~> 2.0)
   webmock
+
+RUBY VERSION
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
rack-mini-profiler may [disclose information to unauthorized users](https://github.com/MiniProfiler/rack-mini-profiler/commit/4273771d65f1a7411e3ef5843329308d0e2d257c)
Newest version (0.10.1) has fix for this.