### PR TITLE
Fix password updating

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,21 @@ module Users
     protected
 
     def update_resource(resource, params)
-      resource.update_without_password(params)
+      resource.update_attributes(params)
+    end
+
+    def account_update_params
+      params = devise_parameter_sanitizer.sanitize(:account_update)
+
+      if passwords_blank?(params)
+        params.except(:password, :password_confirmation)
+      else
+        params
+      end
+    end
+
+    def passwords_blank?(params)
+      params[:password].blank? && params[:password_confirmation].blank?
     end
   end
 end

--- a/spec/features/user/account/update_spec.rb
+++ b/spec/features/user/account/update_spec.rb
@@ -8,9 +8,16 @@ feature "Update Account" do
   end
 
   scenario "User updates account with valid data" do
-    fill_form(:user, full_name: "New Name")
+    fill_form(:user, :edit, full_name: "New Name")
     click_on "Update"
 
     expect(page).to have_content("New Name")
+  end
+
+  scenario "User enters not matched passwords" do
+    fill_form(:user, :edit, password: "qwerty", password_confirmation: "123123")
+    click_on "Update"
+
+    expect(page).to have_content("doesn't match Password")
   end
 end


### PR DESCRIPTION
Fixes #463 
Actually `#update_without_password` does not allow to change password http://www.rubydoc.info/github/plataformatec/devise/Devise%2FModels%2FDatabaseAuthenticatable%3Aupdate_without_password