### PR TITLE
Override decorator template

### DIFF
--- a/lib/templates/rails/decorator/decorator.rb
+++ b/lib/templates/rails/decorator/decorator.rb
@@ -1,0 +1,8 @@
+<%- module_namespacing do -%>
+  <%- if parent_class_name.present? -%>
+class <%= class_name %>Decorator < <%= parent_class_name %>
+  <%- else -%>
+class <%= class_name %>
+  <%- end -%>
+end
+<% end -%>


### PR DESCRIPTION
In order to eliminate creation draper decorators with `delegate_all` and example of hot to use decorators i've rewritten the template.