### PR TITLE
Update readme

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,3 @@
 brew "postgresql"
-brew "qt"
 brew "phantomjs"
 brew "graphviz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove `qt` from Brewfile and dependencies list
 - Upgrade Ruby to 2.3.3, Nokogiri to 1.7.1
 - Upgrade [decent exposure](https://github.com/hashrocket/decent_exposure) to 3.0
 - Email previews for `DeviseMailer` at http://lvh.me:5000/rails/mailers

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ It's based on Rails 5 and Ruby 2.3.3.
 Some gems have native extensions.
 You should have GCC installed on your development machine.
 
-* `qt` - to run specs with [Capybara Webkit](https://github.com/thoughtbot/capybara-webkit)
 * `phantomjs` - to run Javascript unit tests
 * `graphviz` - to generate Entity-Relationship Diagram
 


### PR DESCRIPTION
Remove `qt` dependency because `poltergeist` used instead of `capybara-webkit`