### PR TITLE
Update Nokogiri to >=1.7.2 for CVE issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.2.0)
     mini_racer (0.1.8)
       libv8 (~> 5.3)
     minitest (5.10.1)
@@ -231,8 +231,8 @@ GEM
     nenv (0.3.0)
     newrelic_rpm (3.18.1.330)
     nio4r (2.0.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -510,4 +510,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.6
+   1.15.1


### PR DESCRIPTION
### What? 
Updating nokogiri to resolve security warnings when running `bin/ci`. Nokogiri 1.7.2 introduced two CVE fixes which 1.7.1 didn't contain. 

* [Nokogiri Changelog](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#172--2017-05-09)
* [CVE-2017-5029](http://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-5029.html)
* [CVE-2016-4738](http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4738.html)

### How to test

1. If necessary, run `bin/setup`
2. Run `bundle install` otherwise for this branch which `bin/setup` would also cover
3. Run `bin/ci`
4. Result should be no security warnings 