### PR TITLE
Make sure 2.4.1 specified in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.3


### PR DESCRIPTION
# Summary

Right now we have 2.4.1 in Gemfile and 2.3.3 in Gemfile.lock

# Test plan

List of steps to manually test introduced functionality:

* Make sure application deployed to Heroku with ruby version 2.4.1

# Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduces DB fields have indexes and constraints
- routes are RESTful, no useless routes
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

# Deploy notes

Nope