### PR TITLE
[RSPEC] Migrating from 'email_spec' gem to 'capybara-email' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,9 +53,9 @@ end
 
 group :test do
   gem "capybara"
+  gem "capybara-email"
   gem "codeclimate-test-reporter", require: false
   gem "database_cleaner"
-  gem "email_spec"
   gem "formulaic"
   gem "guard-rspec"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
     autoprefixer-rails (6.7.4)
@@ -75,13 +75,16 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.0.6)
-    capybara (2.12.1)
+    capybara (2.15.4)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-email (2.5.0)
+      capybara (~> 2.4)
+      mail
     choice (0.2.0)
     cliver (0.3.2)
     codeclimate-test-reporter (0.6.0)
@@ -126,10 +129,6 @@ GEM
       activemodel-serializers-xml (~> 1.0)
       activesupport (~> 5.0)
       request_store (~> 1.0)
-    email_spec (2.1.0)
-      htmlentities (~> 4.3.3)
-      launchy (~> 2.1)
-      mail (~> 2.6.3)
     erubi (1.6.1)
     execjs (2.7.0)
     factory_girl (4.8.0)
@@ -221,6 +220,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_mime (0.1.4)
     mini_portile2 (2.3.0)
     mini_racer (0.1.8)
       libv8 (~> 5.3)
@@ -257,7 +257,7 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.5)
       pry (>= 0.9.10)
-    public_suffix (2.0.5)
+    public_suffix (3.0.0)
     puma (3.9.1)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
@@ -428,7 +428,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -443,6 +443,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara
+  capybara-email
   codeclimate-test-reporter
   coffee-rails
   coffeelint
@@ -452,7 +453,6 @@ DEPENDENCIES
   devise
   dotenv-rails
   draper
-  email_spec
   factory_girl_rails
   faker
   flamegraph

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,7 @@ Rails.application.configure do
 
   # Run specs in order
   config.active_support.test_order = :sorted
+
+  # Host for capybara-email gem
+  config.action_mailer.default_url_options = { host: "www.example.com" }
 end

--- a/spec/features/visitor/password_reset_spec.rb
+++ b/spec/features/visitor/password_reset_spec.rb
@@ -18,10 +18,11 @@ feature "Password Reset" do
 
     open_email(user.email)
 
-    expect(current_email).to have_subject("Reset password instructions")
-    expect(current_email).to have_body_text(user.full_name)
+    expect(current_email.header("Subject")).to eq("Reset password instructions")
+    expect(current_email).to have_content(user.full_name)
 
-    visit_in_email("Change my password")
+    current_email.click_link("Change my password")
+
     update_password
 
     expect(page).to have_content("Your password has been changed successfully")

--- a/spec/features/visitor/resend_confirmation_email_spec.rb
+++ b/spec/features/visitor/resend_confirmation_email_spec.rb
@@ -11,7 +11,7 @@ feature "Resend Confirmation Email" do
 
     open_email(user.email)
 
-    expect(current_email).to have_subject("Confirmation instructions")
-    expect(current_email).to have_body_text(user.full_name)
+    expect(current_email.header("Subject")).to eq("Confirmation instructions")
+    expect(current_email).to have_content(user.full_name)
   end
 end

--- a/spec/features/visitor/sign_up_spec.rb
+++ b/spec/features/visitor/sign_up_spec.rb
@@ -12,12 +12,12 @@ feature "Sign Up" do
 
     open_email(registered_user.email)
 
-    expect(current_email).to have_subject("Confirmation instructions")
-    expect(current_email).to have_body_text(registered_user.full_name)
+    expect(current_email.header("Subject")).to eq("Confirmation instructions")
+    expect(current_email).to have_content(registered_user.full_name)
 
-    visit_in_email("Confirm my account")
+    current_email.click_link("Confirm my account")
 
     expect(page).to have_content("Your email address has been successfully confirmed")
-    expect(page).to have_text(registered_user.full_name)
+    expect(page).to have_content(registered_user.full_name)
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,5 @@
 require "capybara/poltergeist"
+require "capybara/email/rspec"
 
 Capybara.configure do |config|
   config.match = :prefer_exact

--- a/spec/support/email.rb
+++ b/spec/support/email.rb
@@ -1,7 +1,4 @@
 RSpec.configure do |config|
-  config.include EmailSpec::Helpers
-  config.include EmailSpec::Matchers
-
   config.before do
     ActionMailer::Base.deliveries.clear
   end


### PR DESCRIPTION
Hey guys :wave:,

I just finished playing with 'capybara-email' gem (https://github.com/DavyJonesLocker/capybara-email)
Here is related [GITHUB ISSUE № 503 `Try Capybara Email`](https://github.com/fs/rails-base/issues/503)

Benchmark test with `email_spec`:
![with email_spec](https://user-images.githubusercontent.com/15632598/32044319-e89726d4-ba45-11e7-80b7-c364e3eeed72.png)

Benchmark test with `capybara-email`:
![with capybara-email](https://user-images.githubusercontent.com/15632598/32044332-f10d686e-ba45-11e7-9b43-5eb4f4f3f10a.png)

As we see, there are no big difference in performance, 
but I like `capybara-email` gem's syntax.

