### PR TITLE
Update nokogiri to 1.8.2 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.4.1)
       launchy (~> 2.2)
-    libv8 (5.3.332.38.3)
+    libv8 (5.9.211.38.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -229,7 +229,7 @@ GEM
     nenv (0.3.0)
     newrelic_rpm (3.18.1.330)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -512,4 +512,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
# Summary

Update nokogiri to `1.8.2` to eliminate CVE-2017-15412
Update libv8 to `5.9.211.38.1` to stop breaking `bin/setup` (mini_racer needs it)

# Test plan

Run `bin/quality` and make sure that no vulnerabilities are found

# Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduces DB fields have indexes and constraints
- routes are RESTful, no useless routes
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

# Deploy notes

–
