### PR TITLE
Update rails-html-sanitizer gem to 1.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,13 +25,13 @@ GEM
       rack (~> 2.0)
       rack-test (~> 0.6.3)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+      rails-html-sanitizer (~> 1.0, >= 1.0.4)
     actionview (5.1.2)
       activesupport (= 5.1.2)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+      rails-html-sanitizer (~> 1.0, >= 1.0.4)
     active_link_to (1.0.3)
       actionpack
     activejob (5.1.2)
@@ -210,7 +210,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.11)
@@ -293,8 +293,8 @@ GEM
       activesupport (>= 3.2)
       choice (~> 0.2.0)
       ruby-graphviz (~> 1.2)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.1.2)
       actionpack (= 5.1.2)
       activesupport (= 5.1.2)
@@ -514,4 +514,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
# Summary

Update rails-html-sanitizer gem to prevent vulnerability: [CVE-2018-3741](https://groups.google.com/forum/#!msg/rubyonrails-security/tP7W3kLc5u4/uDy2Br7xBgAJ)

# Test plan

Run `bin/quality`