### PR TITLE
Updated rack-mini-profiler to prevent warning messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+- Updated rack-mini-profiler to version 1.1.3
 - Ruby updated to version 2.5.7
 - Replace gem [metamagic](https://github.com/lassebunk/metamagic) to [meta-tags](https://github.com/kpumuk/meta-tags). Using for CEO.
 - Remove `qt` from Brewfile and dependencies list

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/MiniProfiler/rack-mini-profiler.git
-  revision: 1b79f49f36dfe16f7a8c9c75753decb37bec186c
+  revision: 6e32b8c1804895027ae3b3910318bd6282827ec2
   specs:
-    rack-mini-profiler (0.10.2)
+    rack-mini-profiler (1.1.3)
       rack (>= 1.2.0)
 
 GEM


### PR DESCRIPTION
# Summary

Updated rack-mini-profiler gem because old version shows warning:

<Rack::MiniProfiler::MemoryStore::CacheCleanupThread:0x00007fbece793170@/Users/vladimir/src/rails-base/.bundle/ruby/2.5.0/bundler/gems/rack-mini-profiler-1b79f49f36df/lib/mini_profiler/storage/memory_store.rb:71 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
/Users/vladimir/src/rails-base/.bundle/ruby/2.5.0/bundler/gems/rack-mini-profiler-1b79f49f36df/lib/mini_profiler/storage/memory_store.rb:73:in `block in initialize_cleanup_thread': undefined method `sleepy_run' for #<Rack::MiniProfiler::MemoryStore:0x00007fbece793288> (NoMethodError)