### PR TITLE
Disable animations for tests to prevent strange flaky tests

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,3 +5,5 @@ Capybara.configure do |config|
 end
 
 Capybara.javascript_driver = :selenium_chrome_headless
+
+Capybara.disable_animation = true


### PR DESCRIPTION
# Summary

https://github.com/fs/rails-base/issues/524

Disable animations for tests to prevent strange flaky tests