### PR TITLE
Replace email spec with capybara email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,8 @@ end
 
 group :test do
   gem "capybara"
+  gem "capybara-email"
   gem "database_cleaner"
-  gem "email_spec"
   gem "formulaic"
   gem "guard-rspec"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    capybara-email (3.0.2)
+      capybara (>= 2.4, < 4.0)
+      mail
     childprocess (3.0.0)
     choice (0.2.0)
     coderay (1.1.1)
@@ -151,10 +154,6 @@ GEM
       activemodel-serializers-xml (>= 1.0)
       activesupport (>= 5.0)
       request_store (>= 1.0)
-    email_spec (2.2.0)
-      htmlentities (~> 4.3.3)
-      launchy (~> 2.1)
-      mail (~> 2.7)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (5.2.0)
@@ -493,13 +492,13 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara
+  capybara-email
   database_cleaner
   decent_decoration
   decent_exposure
   devise
   dotenv-rails
   draper
-  email_spec
   factory_bot_rails
   faker
   flamegraph

--- a/spec/features/visitor/password_reset_spec.rb
+++ b/spec/features/visitor/password_reset_spec.rb
@@ -18,10 +18,10 @@ feature "Password Reset" do
 
     open_email(user.email)
 
-    expect(current_email).to have_subject("Reset password instructions")
-    expect(current_email).to have_body_text(user.full_name)
+    expect(current_email.subject).to eq("Reset password instructions")
+    expect(current_email).to have_content(user.full_name)
 
-    visit_in_email("Change my password")
+    current_email.click_link("Change my password")
     update_password
 
     expect(page).to have_content("Your password has been changed successfully")

--- a/spec/features/visitor/resend_confirmation_email_spec.rb
+++ b/spec/features/visitor/resend_confirmation_email_spec.rb
@@ -11,7 +11,7 @@ feature "Resend Confirmation Email" do
 
     open_email(user.email)
 
-    expect(current_email).to have_subject("Confirmation instructions")
-    expect(current_email).to have_body_text(user.full_name)
+    expect(current_email.subject).to eq("Confirmation instructions")
+    expect(current_email).to have_content(user.full_name)
   end
 end

--- a/spec/features/visitor/sign_up_spec.rb
+++ b/spec/features/visitor/sign_up_spec.rb
@@ -12,10 +12,10 @@ feature "Sign Up" do
 
     open_email(registered_user.email)
 
-    expect(current_email).to have_subject("Confirmation instructions")
-    expect(current_email).to have_body_text(registered_user.full_name)
+    expect(current_email.subject).to eq("Confirmation instructions")
+    expect(current_email).to have_content(registered_user.full_name)
 
-    visit_in_email("Confirm my account")
+    current_email.click_link("Confirm my account")
 
     expect(page).to have_content("Your email address has been successfully confirmed")
     expect(page).to have_text(registered_user.full_name)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 require "shoulda/matchers"
+require "capybara/email/rspec"
 
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,3 +5,5 @@ Capybara.configure do |config|
 end
 
 Capybara.javascript_driver = :selenium_chrome_headless
+
+Capybara.disable_animation = true

--- a/spec/support/email.rb
+++ b/spec/support/email.rb
@@ -1,8 +1,0 @@
-RSpec.configure do |config|
-  config.include EmailSpec::Helpers
-  config.include EmailSpec::Matchers
-
-  config.before(:each) do
-    ActionMailer::Base.deliveries.clear
-  end
-end


### PR DESCRIPTION
# Summary

https://github.com/fs/rails-base/issues/503

Replaced email_spec gem with capybara_email